### PR TITLE
Fixed problem on 'next lesson' buttons

### DIFF
--- a/app/controllers/classrooms_controller.rb
+++ b/app/controllers/classrooms_controller.rb
@@ -26,9 +26,9 @@ class ClassroomsController < ApplicationController
   def next
     @classroom = Classroom.find(params[:id])
     @lecture = @classroom.lectures.find_by(status: 'ongoing')
-    @lecture.done!
+    @lecture.done! unless !@lecture
     @next_lecture = Lecture.find_by(status: "pending", classroom: @classroom)
-    @next_lecture.ongoing!
+    @next_lecture.ongoing! unless !@lecture
     authorize @classroom
     redirect_to course_classroom_path(@classroom.course, @classroom)
   end


### PR DESCRIPTION
Used an unless condition on lectures to prevent error 500 when the newt method was out of lectures on which to change status